### PR TITLE
"steal" to "use" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Medium's Policies and Guidelines
 
 This is where we keep past and current versions of Medium's Policies and Guidelines. 
 
-We've made these policies available under a Creative Commons Sharealike license, which means you’re more than welcome to steal them and repurpose them for your own use. Please just make sure to replace references to us with ones to you! 
+We've made these policies available under a Creative Commons Sharealike license, which means you’re more than welcome to use them and repurpose them for your own use. Please just make sure to replace references to us with ones to you! 
 
 If you have any questions, email us at yourfriends@medium.com. 
 


### PR DESCRIPTION
It's not fair to refer to using CC-licensed content for other purposes as stealing, since the license itself is intended to allow others to use it.